### PR TITLE
req.headers update

### DIFF
--- a/src/wp.js
+++ b/src/wp.js
@@ -40,7 +40,7 @@ export default class Wp {
         const req = await axios.get(query_endpoint)
         this.content_types[content_name] = this.content_types[content_name].concat(req.data)
         if (page_i === 1) {
-          page_max_i = req.headers['X-WP-TotalPages']
+          page_max_i = req.headers['x-wp-totalpages']
         }
       } catch (err) {
         console.log(`Error while fetching entries from WordPress: ${err.message}`)


### PR DESCRIPTION
req.headers is case sensitive when accessing a json key vs an actual headers key. The function only runs twice since this would otherwise return an undefined amount