### PR TITLE
Make per_page (for downloading WP content) value configurable

### DIFF
--- a/src/migration.js
+++ b/src/migration.js
@@ -12,7 +12,8 @@ const settings_defaults = {
     enabled: true,
     types: ['png', 'jpg', 'jpeg', 'gif', 'png', 'svg', 'pdf'],
     restrict_domain: false
-  }
+  },
+  max_per_page: 50
 }
 
 export default class Wp2Storyblok {
@@ -22,7 +23,7 @@ export default class Wp2Storyblok {
     this.endpoint = endpoint
     this.settings = { ...settings_defaults, ...settings }
     // Storyblok and WP Interfaces
-    this.wp = new Wp({endpoint: this.endpoint})
+    this.wp = new Wp({endpoint: this.endpoint, max_per_page: this.settings.max_per_page})
     this.storyblok = new Storyblok({ token: settings.token, space_id: settings.space_id })
     // Data to migrate
     this.stories_to_migrate = []

--- a/src/wp.js
+++ b/src/wp.js
@@ -39,6 +39,9 @@ export default class Wp {
         query_endpoint += `per_page=${this.max_per_page}&page=${page_i}`
 
         const req = await axios.get(query_endpoint)
+        if (typeof req.data !== 'object') {
+          throw `Unexpected response: ${req.data}`
+        }
         this.content_types[content_name] = this.content_types[content_name].concat(req.data)
         if (page_i === 1) {
           page_max_i = req.headers['X-WP-TotalPages'] || req.headers['x-wp-totalpages']

--- a/src/wp.js
+++ b/src/wp.js
@@ -4,6 +4,7 @@ import axios from 'axios'
 export default class Wp {
   constructor(settings) {
     this.endpoint = settings.endpoint
+    this.max_per_page = settings.max_per_page || 50
     this.content_types = {}
   }
 
@@ -21,9 +22,9 @@ export default class Wp {
   }
 
   /**
-   * Get all posts associated with a content type and 
+   * Get all posts associated with a content type and
    * stores them in an array in the class object
-   * @param {String} content_name 
+   * @param {String} content_name
    */
   async getPosts(content_name) {
     this.content_types[content_name] = []
@@ -35,7 +36,7 @@ export default class Wp {
         query_endpoint += '/wp/v2/'
         query_endpoint += content_name
         query_endpoint +=  this.endpoint.includes('?') ? '&' : '?'
-        query_endpoint += `per_page=50&page=${page_i}`
+        query_endpoint += `per_page=${this.max_per_page}&page=${page_i}`
 
         const req = await axios.get(query_endpoint)
         this.content_types[content_name] = this.content_types[content_name].concat(req.data)


### PR DESCRIPTION
WordPress servers are typically not very strong and 50 items/page can be a bit much.
In a case I just had, WordPress was even responding with the wrong result - an empty string instead of valid json or status headers.

Unfortunately, monkey-patching involves a lot of code and is in the end not very desirable to hack the package's internals.

This patch should be backward compatible and:
1. makes the per_page amount configurable, defaulting to 50, as before
2. throws an exception when it gets an unexpected response from the api (namely "not an object")

**Note: I haven't tested the changes yet.**